### PR TITLE
Fix: Remove duplicate formatOnType in JsonEditor

### DIFF
--- a/src/components/document/JsonEditor.tsx
+++ b/src/components/document/JsonEditor.tsx
@@ -46,7 +46,6 @@ export function JsonEditor({
         automaticLayout: true,
         formatOnPaste: true,
         formatOnType: true,
-        formatOnType: true,
         theme: document.documentElement.classList.contains('dark') ? 'vs-dark' : 'vs-light'
       }}
     />


### PR DESCRIPTION
Removes the redundant `formatOnType: true` declaration within the Monaco Editor options in `src/components/document/JsonEditor.tsx`.